### PR TITLE
ci: fix GHCR image push permission denied

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,12 @@ jobs:
       - name: run integration test with Earthly
         run: earthly --ci --verbose --allow-privileged +test
 
+      - name: login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          retgistry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: build and publish image
-        env:
-          EARTHLY_TOKEN: ${{ secrets.GHCR_AUTH_TOKEN }}
         run: earthly --ci --verbose --push +freeradius-image --FREERADIUS_IMAGE_TAG=${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
* Try to authenticate with the GHCR [1] by the
  + registry: ghcr.io
  + username: github.actor
  + password: secrets.GITHUB_TOKEN

---
[1] https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action