### PR TITLE
fix: fail to build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: earthly/actions/setup-earthly@v1 
         with:
-          version: v0.5.24
+          version: v0.7.1
 
       - name: run integration test with Earthly
         run: earthly --ci --verbose --allow-privileged +test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: earthly/actions/setup-earthly@v1 
         with:
-          version: v0.5.24
+          version: v0.7.1
 
       - name: run integration test with Earthly
         run: earthly --ci --verbose --allow-privileged +test

--- a/Earthfile
+++ b/Earthfile
@@ -1,8 +1,7 @@
+VERSION 0.7
+
 FROM debian:bullseye
 LABEL maintainer="Neutron Soutmun <neutron@neutron.in.th>"
-
-ARG FREERADIUS_DEBIAN_SRC_VERSION=3.0.21+dfsg-2.2+deb11u1
-ARG FREERADIUS_IMAGE_TAG=3.0.21-dfsg-2.2-deb11u1-sforcenetworks1
 
 debian-builder:
   FROM debian:bullseye
@@ -30,6 +29,7 @@ debian-builder:
 
 clickhouse-cpp-lib:
   FROM +debian-builder
+  ARG LIB_VERSION=v2.3.0
 
   RUN --mount=type=cache,target=/var/cache/apt \
     apt-get install --yes --no-install-recommends \
@@ -39,6 +39,7 @@ clickhouse-cpp-lib:
   RUN git clone https://github.com/ClickHouse/clickhouse-cpp.git
 
   RUN cd clickhouse-cpp \
+    && git checkout "$LIB_VERSION" \
     && cmake . \
     && make \
     && make install
@@ -47,6 +48,9 @@ clickhouse-cpp-lib:
   SAVE ARTIFACT /usr/local/include/clickhouse /include/clickhouse
 
 freeradius-deb-src:
+  ARG FREERADIUS_DEBIAN_SRC_VERSION=3.0.21+dfsg-2.2+deb11u1
+  ARG FREERADIUS_IMAGE_TAG=3.0.21-dfsg-2.2-deb11u1-sforcenetworks1
+
   FROM +debian-builder
   ENV DEBMAIL="Neutron Soutmun <neutron@neutron.in.th>"
 
@@ -116,7 +120,7 @@ freeradius-image:
   SAVE IMAGE --push ghcr.io/sforcenetworks/freeradius:${FREERADIUS_IMAGE_TAG}
 
 test:
-  FROM docker:20.10-dind
+  FROM docker:23.0-dind
 
   RUN apk add --no-cache git bash \
     && git clone https://github.com/bats-core/bats-core.git \

--- a/tests/integration-test.bats
+++ b/tests/integration-test.bats
@@ -2,8 +2,8 @@
 
 CLICKHOUSE_CLIENT_IMAGE="yandex/clickhouse-client:21"
 CLICKHOUSE_HOST="tcp://clickhouse:9000"
-TEST_PREFIX="tests_"
-TEST_NETWORK="${TEST_PREFIX}test"
+TEST_PREFIX="tests"
+TEST_NETWORK="${TEST_PREFIX}_test"
 
 docker_test_run() {
   docker run --rm --network="$TEST_NETWORK" "$@"
@@ -16,7 +16,7 @@ setup() {
   docker_test_run jwilder/dockerize:latest  \
     -wait "$CLICKHOUSE_HOST" -timeout 10s
 
-  docker cp freeradius/test-scripts "${TEST_PREFIX}freeradius_1:/"
+  docker cp freeradius/test-scripts "${TEST_PREFIX}-freeradius-1:/"
 }
 
 show_tables() {


### PR DESCRIPTION
* Pin clickhouse-cpp-lib to v2.3.0 (latest release)
* Bump
  + Earthly to v0.7.1
  + Docker(dind) to 23.0
* Adjust Earthfile
  + The explicit ARG passing is required,
    therefore, for flexibility, move the
      + FREERADIUS_DEBIAN_SRC_VERSION
      + FREERADIUS_IMAGE_TAG
    to the required target
* Adjust integration-test, the container's name
  was changed in the recent Docker version
